### PR TITLE
Radial SF, Starting frame options, force_recompute, interpolation fix

### DIFF
--- a/main_gromacs.py
+++ b/main_gromacs.py
@@ -21,6 +21,8 @@ parser = argparse.ArgumentParser(description='Calculate 3d Structure Factor')
 parser.add_argument('-i', '--input', default='', type=str, help='Input topolgy and trajectory basename')
 parser.add_argument('-top', '--topology', default='', type=str, help='Input topolgy filename')
 parser.add_argument('-traj', '--trajectory', default='', type=str, help='Input trajectory filename')
+parser.add_argument('-fi', '--first_frame', default=0, type=int, help='frame to start at')
+parser.add_argument('-fr', '--force_recompute', default=0, type=int, help='force recomputing SF (if >=1) or trajectory and SF(if >=2)')
 #parser.add_argument('-o', '--output', default='', type=str, help='override output basename')
 
 
@@ -56,19 +58,29 @@ sfname=label+"_sf"
 dens.Nspatialgrid=128
 
 
-if not os.path.isfile(sfname+".npz"):					#check to see if SF needs to be calculated
-	if not os.path.isfile(tfname+".npz"):  				#check to see if trajectory needs to be processed
+if args.force_recompute>0 or not os.path.isfile(sfname+".npz"):					#check to see if SF needs to be calculated
+	if args.force_recompute>1 or not os.path.isfile(tfname+".npz"):  				#check to see if trajectory needs to be processed
 		print "processing trajectory file "+traj_file
 		lt.process_gro(top_file,traj_file,tfname)   					#Process trajectory into numpy array.  Commented to run on windows
 		print 'done'
 	traj=np.load(tfname+".npz")							#load processed trajectory
 	rad=dens.load_radii("radii.txt")					#load radii definitions from file
 
-	dens.compute_sf(traj['coords'],traj['dims'],traj['typ'],sfname,rad)		#compute time-averaged 3d structure factor and save to sfname.npz
+	dens.compute_sf(traj['coords'][args.first_frame:,...],traj['dims'],traj['typ'],sfname,rad)		#compute time-averaged 3d structure factor and save to sfname.npz
 
 
 dpl=np.load(sfname+".npz")					#load 3d SF
+
 grid=dpl['kgridplt']
+
+#print grid[:,0,0,0]
+#print grid.shape
+#exit()
+#print grid[grid.shape[0]/2,grid.shape[1]/2,grid.shape[2]/2,3]
+#print grid[grid.shape[0]/2+1,grid.shape[1]/2,grid.shape[2]/2,3]
+#exit()
+
+
 
 p2d.mainlabel=basename			#title for plots
 
@@ -77,18 +89,24 @@ sfdir=dir+"structure_factor"+fd
 sfsubdir=sfdir+"additional_plots"+fd
 EWdir=dir+"Ewald_Corrected"+fd
 
-p2d.path=EWdir
-p2d.Plot_Ewald_Sphere_Correction(grid,1.54)		#compute Ewald-corrected SF cross sections in xy,xz,yz planes
+
+if True:
+	print "Ewald plots"
+	p2d.path=EWdir
+	p2d.Plot_Ewald_Sphere_Correction(grid,1.54)		#compute Ewald-corrected SF cross sections in xy,xz,yz planes
 
 #xy,yz,xz planes of SF
 if True:
+	print "xy,yz,xz plots"
 	p2d.path=dir+sfdir
 	p2d.sfplot(grid[grid.shape[0]/2,:,:,:])		#plot yz plane
 	p2d.sfplot(grid[:,grid.shape[1]/2,:,:])		#plot xz plane
 	p2d.sfplot(grid[:,:,grid.shape[2]/2,:])		#plot xy plane
+	p2d.radial_integrate(grid,300,dir+"radial.png")
 
 
 if True:  #additional slices through SF
+	print "additional plots"
 	Nsteps=8
 	p2d.path=sfsubdir+"xplots"+fd
 	p2d.savelin=False

--- a/plot2d.py
+++ b/plot2d.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 import os
 from scipy.interpolate import RegularGridInterpolator
 import math
+import tqdm
 
 mainlabel=""
 
@@ -77,6 +78,59 @@ def sfplot(data,**kwargs):
 		plt.savefig(filename+format,dpi=DPI)
 		plt.clf()
 
+def radial_integrate(D,Nbins,outputname):
+
+
+
+	#X =D[:,0,0,0]
+	#Y =D[0,:,0,1]
+	#Z =D[0,0,:,2]
+	
+	SF=D[:,:,:,3]
+	#SF[SF.shape[0]/2,SF.shape[1]/2,SF.shape[2]/2]=0.0
+	
+	#for i in tqdm.tqdm(xrange(100)):
+		#SF[np.unravel_index(np.argmax(SF),(SF.shape))]=0.0
+		
+	#print SF.shape[0]/2,SF.shape[1]/2,SF.shape[2]/2
+	#SF[127,126,127]=0.0
+	#exit()
+	R=(D[:,:,:,0]**2).astype(np.float16)+(D[:,:,:,1]**2).astype(np.float16)+(D[:,:,:,2]**2).astype(np.float16)
+	H,E=np.histogram(R,bins=Nbins,weights=SF)
+	Hc,E=np.histogram(R,bins=Nbins)
+	Hc=np.where(Hc!=0,Hc,1.0)
+	H/=Hc
+	H[:1]=0.0
+	H/=np.amax(H)
+	
+	#print np.argmax(H)
+	
+	
+	plt.plot(E[:-1],H)
+	plt.xlim(0,5)
+	plt.savefig(outputname,dpi=DPI)
+	
+	
+	#print H
+	#print type(H)
+	#print H.shape
+	#print H.shape
+	#print R
+	#print R.shape
+	
+		
+	# ES = RegularGridInterpolator((X, Y, Z), SF)	
+	
+	# pts=[]
+	# for x in np.linspace(np.amin(X),np.amax(X),X.size*Ni):
+		# for y in np.linspace(np.amin(Y),np.amax(Y),Y.size*Ni):
+			# for z in np.linspace(np.amin(Z),np.amax(Z),Z.size*Ni):
+				# pts.append((x,y,z))
+			
+	# A=ES(pts)
+	# B=
+	
+
 
 
 def Plot_Ewald_Sphere_Correction_old(D,wavelength_angstroms):  #pass full 3d data,SF,wavelength in angstroms
@@ -120,6 +174,8 @@ def Plot_Ewald_Sphere_Correction_old(D,wavelength_angstroms):  #pass full 3d dat
 def Plot_Ewald_Sphere_Correction(D,wavelength_angstroms,**kwargs):  #pass full 3d data,SF,wavelength in angstroms
 
 
+	print D.shape
+
 	if not os.path.exists(path):
 		os.makedirs(path)
 	
@@ -130,7 +186,7 @@ def Plot_Ewald_Sphere_Correction(D,wavelength_angstroms,**kwargs):  #pass full 3
 	
 	K_ES=2.0*math.pi/wavelength_angstroms  #calculate k for incident xrays in inverse angstroms
 	
-	ES = RegularGridInterpolator((X, Y, Z), SF)		
+	ES = RegularGridInterpolator((X, Y, Z), SF,bounds_error=False)		
 	
 	xypts=[]
 	for ix in xrange(D.shape[0]):


### PR DESCRIPTION
Updated to include radial SF and starting from frames other than the
first one.  

Added -force_recompute flag to command line options.
This option can be set to 1 to recompute only the SF, or to 2 or higher
to reload the trajectory and recompute SF.

Fixed interpolation bug, now extrapolation can occur.  